### PR TITLE
Quickstart documentation fix 

### DIFF
--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -41,10 +41,11 @@ RPK should technically work against most flavors of Kubernetes, however it has l
 platform.  The following table outlines the common supported installations of RPK that have been tested.  Other variations
 may work:
 
-| ---- | ------ |
-| Kubernetes Versions | 1.16 thru 1.20 |
-| CNI Plugin | Antrea or Calico |
-| TKG Versions | 1.1 thru 1.3 |
+| Component    | Supported Versions |
+| ------------ | ------------------ |
+| Kubernetes   | 1.16 thru 1.20     |
+| CNI Plugin   | Antrea or Calico   |
+| TKG Versions | 1.1 thru 1.3       |
 
 ## Administrative Access
 


### PR DESCRIPTION
Fix for bad table formatting in quick start guide

Fixes https://github.com/vmware-tanzu-labs/reference-platform-for-kubernetes/issues/35
